### PR TITLE
Fix compiling issues on Linux.

### DIFF
--- a/build_compiler.sh
+++ b/build_compiler.sh
@@ -114,7 +114,7 @@ cd archive
 if [ ! -e binutils-2.24.tar.bz2 ] ; then
   echo
   echo "Downloading binutils-2.24.tar.bz2 from ftp.gnu.org";
-  curl.exe -L -O -R https://ftp.gnu.org/gnu/binutils/binutils-2.24.tar.bz2
+  curl -L -O -R https://ftp.gnu.org/gnu/binutils/binutils-2.24.tar.bz2
 
   if [ $? != 0 ]; then
     echo "Error: Cannot download the required version of the binutils source";
@@ -127,7 +127,7 @@ fi
 if [ ! -e gcc-4.7.4.tar.bz2 ] ; then
   echo
   echo "Downloading gcc-4.7.4.tar.bz2 from ftp.gnu.org";
-  curl.exe -L -O -R https://ftp.gnu.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2
+  curl -L -O -R https://ftp.gnu.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2
 
   if [ $? != 0 ]; then
     echo "Error: Cannot download the required version of the gcc source";
@@ -140,7 +140,7 @@ fi
 if [ ! -e newlib-2.2.0-1.tar.gz ] ; then
   echo
   echo "Downloading newlib-2.2.0-1.tar.gz from sourceware.org";
-  curl.exe -L -O -R ftp://sourceware.org/pub/newlib/newlib-2.2.0-1.tar.gz
+  curl -L -O -R ftp://sourceware.org/pub/newlib/newlib-2.2.0-1.tar.gz
 
   if [ $? != 0 ]; then
     echo "Error: Cannot download the required version of the newlib source";

--- a/patch/binutils-2.24-gcc-7.3.patch
+++ b/patch/binutils-2.24-gcc-7.3.patch
@@ -6,7 +6,7 @@ diff -Naur binutils-2.24-pure/bfd/configure binutils-2.24/bfd/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  
@@ -18,7 +18,7 @@ diff -Naur binutils-2.24-pure/bfd/warning.m4 binutils-2.24/bfd/warning.m4
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  		   
@@ -30,7 +30,7 @@ diff -Naur binutils-2.24-pure/binutils/configure binutils-2.24/binutils/configur
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  
@@ -141,7 +141,7 @@ diff -Naur binutils-2.24-pure/gas/configure binutils-2.24/gas/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  
@@ -186,7 +186,7 @@ diff -Naur binutils-2.24-pure/gold/configure binutils-2.24/gold/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  
@@ -228,7 +228,7 @@ diff -Naur binutils-2.24-pure/gprof/configure binutils-2.24/gprof/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  
@@ -240,7 +240,7 @@ diff -Naur binutils-2.24-pure/ld/configure binutils-2.24/ld/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  
@@ -343,7 +343,7 @@ diff -Naur binutils-2.24-pure/opcodes/configure binutils-2.24/opcodes/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough"
      NO_WERROR="-Wno-error"
  fi
  

--- a/patch/binutils-2.24-gcc-8.0.patch
+++ b/patch/binutils-2.24-gcc-8.0.patch
@@ -6,7 +6,7 @@ diff -Naur binutils-2.24-pure/bfd/configure binutils-2.24/bfd/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  
@@ -18,7 +18,7 @@ diff -Naur binutils-2.24-pure/bfd/warning.m4 binutils-2.24/bfd/warning.m4
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  		   
@@ -30,7 +30,7 @@ diff -Naur binutils-2.24-pure/binutils/configure binutils-2.24/binutils/configur
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  
@@ -141,7 +141,7 @@ diff -Naur binutils-2.24-pure/gas/configure binutils-2.24/gas/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  
@@ -204,7 +204,7 @@ diff -Naur binutils-2.24-pure/gold/configure binutils-2.24/gold/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  
@@ -246,7 +246,7 @@ diff -Naur binutils-2.24-pure/gprof/configure binutils-2.24/gprof/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  
@@ -258,7 +258,7 @@ diff -Naur binutils-2.24-pure/ld/configure binutils-2.24/ld/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  
@@ -361,7 +361,7 @@ diff -Naur binutils-2.24-pure/opcodes/configure binutils-2.24/opcodes/configure
  NO_WERROR=
  if test "${ERROR_ON_WARNING}" = yes ; then
 -    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror"
-+    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Werror -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
++    GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wno-implicit-fallthrough -Wno-cast-function-type -Wno-stringop-truncation"
      NO_WERROR="-Wno-error"
  fi
  


### PR DESCRIPTION
This should also still work on Windows.
Werror prevents binutils from being compiled with GCC 9.3.