### PR TITLE
Enable dwarf debug info

### DIFF
--- a/patch/gcc-4.9.4-v810.patch
+++ b/patch/gcc-4.9.4-v810.patch
@@ -4088,12 +4088,7 @@ diff -Naur gcc-4.9.4-pure/gcc/config/v810/v810.h gcc-4.9.4/gcc/config/v810/v810.
 +/* We don't have to worry about dbx compatibility for the v810.  */
 +#define DEFAULT_GDB_EXTENSIONS 1
 +
-+/* Use stabs debugging info by default.  */
-+#undef PREFERRED_DEBUGGING_TYPE
-+#define PREFERRED_DEBUGGING_TYPE DBX_DEBUG
-+
 +/* Use dwarf2 debugging info by default.  */
-+/* Not, quite yet on the V810 ...
 +#undef  PREFERRED_DEBUGGING_TYPE
 +#define PREFERRED_DEBUGGING_TYPE   DWARF2_DEBUG
 +
@@ -4106,7 +4101,6 @@ diff -Naur gcc-4.9.4-pure/gcc/config/v810/v810.h gcc-4.9.4/gcc/config/v810/v810.
 +#define ASM_GENERATE_INTERNAL_LABEL(STRING, PREFIX, NUM)  \
 +  sprintf (STRING, "*.%s%u", PREFIX, (unsigned int)(NUM))
 +#endif
-+*/
 +
 +/* Specify the machine mode that this machine uses
 +   for the index in the tablejump instruction.  */


### PR DESCRIPTION
Hi!

I've been working on [a debugger for a Virtual Boy emulator](https://git.virtual-boy.com/PVB/lemur/src/commit/fda738fb93778c091a40a14852f4fc8862563694/src/gdbserver.rs), which integrates with [the lldb binary from v810-llvm](https://github.com/SupernaviX/v810-llvm). That debugger works fine with games compiled via llvm, but most devs use gcc, and I don't want to make devs replace their whole stack just to use a debugger.

I don't pretend to understand exactly what these commented-out lines do, but without them `-g` and `-ggdb` don't produce dwarf information and `-gdwarf-2` causes an ICE. With them, a simple test program compiled with `-g` exposes enough information for lldb to find stack frames and local variables and sourcemaps and other goodies.

![image](https://github.com/user-attachments/assets/4c66c59c-ec9e-456c-bdca-bd4610d30af4)
